### PR TITLE
Add name uniqueness check for player registration

### DIFF
--- a/controller/GameManagerController.java
+++ b/controller/GameManagerController.java
@@ -176,8 +176,12 @@ public void actionPerformed(ActionEvent e) {
         gameData.getAllPlayers().add(player1);
         gameData.getAllPlayers().add(player2);
 
-        // Save the updated game data with the new players
+        // Persist
         SaveLoadService.saveGame(gameData);  // Save the game data with the newly added players
+
+        // Update in-memory list
+        players.add(player1);
+        players.add(player2);
 
         System.out.println("Players " + player1Name + " and " + player2Name + " have been registered.");
     }
@@ -240,5 +244,17 @@ public void actionPerformed(ActionEvent e) {
      */
     public List<Player> getPlayers() {
         return Collections.unmodifiableList(players);
+    }
+
+    /**
+     * Checks whether a proposed player name already exists.
+     *
+     * @param name the player name to verify
+     * @return {@code true} if no registered player has this name
+     */
+    public boolean isNameUnique(String name) {
+        InputValidator.requireNonBlank(name, "player name");
+        return players.stream()
+                .noneMatch(p -> p.getName().equalsIgnoreCase(name));
     }
 }

--- a/controller/SceneManager.java
+++ b/controller/SceneManager.java
@@ -99,20 +99,24 @@ public final class SceneManager {
                         // Show an error message if names are empty
                         JOptionPane.showMessageDialog(playerRegView, "Both player names must be entered.", 
                                 "Error", JOptionPane.ERROR_MESSAGE);
+                    } else if (!gameManagerController.isNameUnique(player1Name)
+                            || !gameManagerController.isNameUnique(player2Name)
+                            || player1Name.equalsIgnoreCase(player2Name)) {
+                        JOptionPane.showMessageDialog(playerRegView,
+                                "Player names must be unique.",
+                                "Error", JOptionPane.ERROR_MESSAGE);
                     } else {
                         // Register the players and save them to the file
-                        GameManagerController controller = new GameManagerController(this, 
-                                new HallOfFameController(new HallOfFameManagementView()), mainMenuView);
-                        controller.handleRegisterPlayers(player1Name, player2Name); // Save the players
+                        gameManagerController.handleRegisterPlayers(player1Name, player2Name);
 
                         // Show confirmation message
-                        JOptionPane.showMessageDialog(playerRegView, "Players Registered: " + player1Name + " and " + player2Name, 
+                        JOptionPane.showMessageDialog(playerRegView, "Players Registered: " + player1Name + " and " + player2Name,
                                 "Success", JOptionPane.INFORMATION_MESSAGE);
 
                         System.out.println("Players Registered: " + player1Name + " and " + player2Name);
 
                         // After successful registration, return to the main menu
-                        showMainMenu(); 
+                        showMainMenu();
                     }
                 }
             }

--- a/model/util/InputValidator.java
+++ b/model/util/InputValidator.java
@@ -157,4 +157,20 @@ public static void requireSize(List<?> list, int expectedSize, String message) t
             throw new IllegalArgumentException("The name " + input + " is already taken.");
         }
     }
+
+    /**
+     * Checks if the provided player name is unique within the given list.
+     *
+     * @param input           the name to check for uniqueness
+     * @param existingPlayers list of already registered players
+     * @return {@code true} if the name does not clash with an existing player
+     */
+    public static boolean isNameUnique(String input, List<Player> existingPlayers) {
+        if (existingPlayers == null) {
+            throw new IllegalArgumentException("existingPlayers must not be null");
+        }
+
+        return existingPlayers.stream()
+                .noneMatch(p -> p.getName().equalsIgnoreCase(input));
+    }
 }


### PR DESCRIPTION
## Summary
- ensure uniqueness of player names when registering
- store new players in memory after saving
- expose `isNameUnique` helper in `GameManagerController`
- provide `InputValidator.isNameUnique` for reuse

## Testing
- `javac model/util/InputValidator.java controller/GameManagerController.java controller/SceneManager.java` *(fails: bad class file versions)*

------
https://chatgpt.com/codex/tasks/task_e_6882ef368da0832892531e517643dc4a